### PR TITLE
Add SRI placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FusionX</title>
   <link rel="icon" href="https://cdn-icons-png.flaticon.com/512/337/337946.png" type="image/png">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
-  <script src="https://unpkg.com/pdf-lib"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" integrity="sha384-PLACEHOLDER" crossorigin="anonymous">
+  <script src="https://unpkg.com/pdf-lib" integrity="sha384-PLACEHOLDER" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add integrity and crossorigin placeholders for PDF-lib and Google Fonts

## Testing
- `curl -Ls https://unpkg.com/pdf-lib | head` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_68706dd35c9883278ace83554cd755f7