### PR TITLE
Fix packaging script

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mkdir -p dist && zip -r dist/FusionX.zip index.html style.css main.js libs fonts README.md
+mkdir -p dist && zip -r dist/FusionX.zip index.html style.css main.js fonts README.md


### PR DESCRIPTION
## Summary
- fix `package.sh` by removing `libs` from the archived paths

## Testing
- `./package.sh`
- `unzip -l dist/FusionX.zip`


------
https://chatgpt.com/codex/tasks/task_e_6870890847148327b5b9f38701ec00a6