### PR TITLE
Fix script import and electron entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,6 @@
     <div class="footer">Développé avec ❤️ par Jeff Longele — vos fichiers ne sont jamais enregistrés.</div>
   </div>
   <script src="./node_modules/pdf-lib/dist/pdf-lib.min.js"></script>
-  <script src="main.js"></script>
+  <script src="renderer.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fusionx",
   "version": "1.0.0",
   "description": "FusionX desktop build",
-  "main": "main.js",
+  "main": "electron.js",
   "scripts": {
     "start": "electron .",
     "pack": "electron-builder --dir",


### PR DESCRIPTION
## Summary
- load renderer.js in the main HTML page
- set Electron's entry point to `electron.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870af0d85d48327afd711540c10aa7b