### PR TITLE
Delay object URL revocation for downloads

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -143,6 +143,6 @@ async function generatePDF(isPreview) {
     a.href = downloadUrl;
     a.download = name.endsWith(".pdf") ? name : name + ".pdf";
     a.click();
-    URL.revokeObjectURL(downloadUrl);
+    setTimeout(() => URL.revokeObjectURL(downloadUrl), 100);
   }
 }


### PR DESCRIPTION
## Summary
- Ensure PDF downloads start before revoking object URLs by delaying `URL.revokeObjectURL`.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b57f1d0d2483279d4410a07fe035e0